### PR TITLE
allow unicode literals

### DIFF
--- a/RDFClosure/Literals.py
+++ b/RDFClosure/Literals.py
@@ -30,6 +30,7 @@ from rdflib import BNode
 from rdflib import Literal as rdflibLiteral
 from rdflib.namespace import XSD as ns_xsd
 
+from . import text_type
 from .RDFS import type
 from .RDFS import Literal
 from .DatatypeHandling import AltXSDToPYTHON
@@ -47,7 +48,7 @@ class _LiteralStructure :
 	# noinspection PyPep8
 	def __init__(self, lit) :
 		self.lit   = lit
-		self.lex   = str(lit)
+		self.lex   = text_type(lit)
 		self.dt    = lit.datatype
 		self.lang  = lit.language
 		self.value = lit.value
@@ -126,9 +127,9 @@ class LiteralProxies :
 				# Test the validity of the datatype
 				if obj.datatype:
 					try:
-						AltXSDToPYTHON[obj.datatype](str(obj))
+						AltXSDToPYTHON[obj.datatype](text_type(obj))
 					except ValueError:
-						closure.add_error("Lexical value of the literal '%s' does not match its datatype (%s)" % (str(obj), obj.datatype))
+						closure.add_error("Lexical value of the literal '%s' does not match its datatype (%s)" % (text_type(obj), obj.datatype))
 
 				# In any case, this should be removed:
 				if t not in to_be_removed:
@@ -200,7 +201,7 @@ class LiteralProxies :
 				# If a literal is an xsd:string then a plain literal is put in its place for the purpose of serialization...
 				lit = self.bnode_to_lit[obj].lit
 				if lit.datatype is not None and lit.datatype == ns_xsd["string"]:
-					lit = rdflibLiteral(str(lit))
+					lit = rdflibLiteral(text_type(lit))
 				to_be_added.append((subj, pred, lit))
 				
 		# Do the real modifications

--- a/RDFClosure/RestrictedDatatype.py
+++ b/RDFClosure/RestrictedDatatype.py
@@ -58,6 +58,7 @@ from rdflib	import Literal as rdflibLiteral
 from rdflib.namespace import XSD as ns_xsd
 
 from DatatypeHandling import AltXSDToPYTHON
+from . import text_type
 
 #: Constant for datatypes using min, max (inclusive and exclusive):
 MIN_MAX					= 0
@@ -196,9 +197,9 @@ def extract_faceted_datatypes(core, graph):
 										# it is caught some lines below anyway...
 										try :
 											if lit.datatype is None or lit.datatype == ns_xsd["string"]:
-												final_facets.append((facet, str(lit)))
+												final_facets.append((facet, text_type(lit)))
 											else :
-												final_facets.append((facet, AltXSDToPYTHON[lit.datatype](str(lit))))
+												final_facets.append((facet, AltXSDToPYTHON[lit.datatype](text_type(lit))))
 										except Exception, msg :
 											core.add_error(msg)
 											continue
@@ -381,7 +382,7 @@ class RestrictedDatatype(RestrictedDatatypeCore):
 		@rtype: boolean
 		"""
 		if isinstance(value, rdflibLiteral) :
-			val = str(value)
+			val = text_type(value)
 		else :
 			val = value
 		if self.minLength is not None :
@@ -396,7 +397,7 @@ class RestrictedDatatype(RestrictedDatatypeCore):
 		@rtype: boolean
 		"""
 		if isinstance(value, rdflibLiteral):
-			val = str(value)
+			val = text_type(value)
 		else :
 			val = value
 		if self.maxLength is not None:
@@ -411,7 +412,7 @@ class RestrictedDatatype(RestrictedDatatypeCore):
 		@rtype: boolean
 		"""
 		if isinstance(value, rdflibLiteral):
-			val = str(value)
+			val = text_type(value)
 		else :
 			val = value
 		if self.length is not None:
@@ -426,7 +427,7 @@ class RestrictedDatatype(RestrictedDatatypeCore):
 		@rtype: boolean
 		"""
 		if isinstance(value, rdflibLiteral):
-			val = str(value)
+			val = text_type(value)
 		else :
 			val = value
 		for p in self.pattern :

--- a/RDFClosure/__init__.py
+++ b/RDFClosure/__init__.py
@@ -151,8 +151,13 @@ __author__ = 'Ivan Herman'
 __contact__ = 'Ivan Herman, ivan@w3.org'
 __license__ = u'W3C® SOFTWARE NOTICE AND LICENSE, http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231'
 
+import sys
 import StringIO
 from types import *
+if sys.version_info < (3,):
+    text_type = unicode
+else:
+    text_type = str
 
 # noinspection PyPackageRequirements,PyPackageRequirements,PyPackageRequirements
 import rdflib
@@ -259,7 +264,7 @@ def interpret_owl_imports(iformat, graph):
 		# this is not 100% kosher. The expected object for an import statement is a URI. However,
 			# on local usage, a string would also make sense, so I do that one, too
 			if isinstance(uri, rdflibLiteral):
-				__parse_input(iformat, str(uri), graph)
+				__parse_input(iformat, text_type(uri), graph)
 			else :
 				__parse_input(iformat, uri, graph)
 			#4. start all over again to see if import statements have been imported


### PR DESCRIPTION
The rdflib `Literal.__str__` uses the python default encoding, which is often ascii and breaks on unicode literals. The safe thing to do is to convert RDF literals to unicode, not str, on python 2.7.
