### PR TITLE
Drop the default encoding of the owlrl script

### DIFF
--- a/scripts/owlrl
+++ b/scripts/owlrl
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 import os
 import sys


### PR DESCRIPTION
The script requires Python 3 and the default is UTF-8. More at

    https://www.python.org/dev/peps/pep-3120/