### PR TITLE
Fix qualified max cardinality 0 bug

### DIFF
--- a/owlrl/OWLRL.py
+++ b/owlrl/OWLRL.py
@@ -717,8 +717,8 @@ class OWLRL_Semantics(Core):
                     for cc in self.graph.objects(xx, onClass):
                         for u, y in self.graph.subject_objects(pp):
                             # This should not occur:
-                            if (y, rdf_type, cc) in self.graph \
-                                    or cc == Thing and (u, rdf_type, xx) in self.graph:
+                            if ((y, rdf_type, cc) in self.graph \
+                                    or cc == Thing) and (u, rdf_type, xx) in self.graph:
 
                                 self.add_error("Erroneous usage of maximum qualified cardinality with %s, %s and %s"
                                                % (xx, cc, y))


### PR DESCRIPTION
Without the brackets, condition applied as (y, rdf_type, cc) in self.graph or (cc == Thing and (u, rdf_type, xx)), which ignores type of u if cc is not Thing.

This leads to incorrectly reporting errors in cases like this where X is not known to be of type B.

@prefix :  <http://ex.org/>.
@prefix owl: <http://www.w3.org/2002/07/owl#>.
@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.

:B rdfs:subClassOf 
   [ owl:maxQualifiedCardinality 0 ; owl:onProperty :p ; owl:onClass :C ] .

:X :p :Y .
:Y a :C .