### PR TITLE
Remove invalid shebang

### DIFF
--- a/owlrl/OWLRL.py
+++ b/owlrl/OWLRL.py
@@ -1,4 +1,3 @@
-#!/d/Bin/Python/python.exe
 # -*- coding: utf-8 -*-
 #
 """


### PR DESCRIPTION
The issue surfaced when packaging for Fedora. I assume this is an oversight. Since none of the other files in the directory have a shebang.