### PR TITLE
Fix owlrl CLI script

### DIFF
--- a/owlrl/__init__.py
+++ b/owlrl/__init__.py
@@ -176,6 +176,12 @@ from .RDFSClosure import RDFS_Semantics
 from .CombinedClosure import RDFS_OWLRL_Semantics
 from rdflib.namespace import OWL
 
+RDFXML = "xml"
+TURTLE = "turtle"
+JSON = "json"
+AUTO = "auto"
+RDFA = "rdfa"
+
 
 # noinspection PyShadowingBuiltins
 def __parse_input(iformat, inp, graph):
@@ -187,25 +193,25 @@ def __parse_input(iformat, inp, graph):
     standard input is used.
     @param graph: the RDFLib Graph instance to parse into.
     """
-    if iformat == "auto":
+    if iformat == AUTO:
         if inp == "-":
             format = "turtle"
         else:
             if inp.endswith(".ttl") or inp.endswith(".n3"):
                 format = "turtle"
-            if inp.endswith(".json") or inp.endswith(".jsonld"):
+            elif inp.endswith(".json") or inp.endswith(".jsonld"):
                 format = "json-ld"
             elif inp.endswith(".html"):
                 format = "rdfa1.1"
             else:
                 format = "xml"
-    elif iformat == "turtle":
-        format = "n3"
-    elif iformat == "rdfa":
+    elif iformat == TURTLE:
+        format = "turtle"
+    elif iformat == RDFA:
         format = "rdfa1.1"
-    elif iformat == "rdfxml":
+    elif iformat == RDFXML:
         format = "xml"
-    elif iformat == "json":
+    elif iformat == JSON:
         format = "json-ld"
     else:
         raise Exception("Unknown input syntax")

--- a/scripts/owlrl
+++ b/scripts/owlrl
@@ -87,7 +87,7 @@ def main():
         options.owlClosure = "yes"
         options.owlExtras = "yes"
             
-    print(convert_graph(options).decode('utf-8'))
+    print(convert_graph(options))
 
 
 # The standard startup idiom...


### PR DESCRIPTION
The `owlrl` command line script broke in version 6 due to removed constants. This fix restores them, and fixes two small bugs:
- The N3 parser was used for Turtle, which fails on e.g. SPARQL-style `PREFIX` and `BASE` keywords. Now uses the proper Turtle parser.
- Automatic Turtle syntax detection from filename was overwritten due to a following `if` instead of an `elif`.