### PR TITLE
Add inferred triples to a separate named graph

### DIFF
--- a/owlrl/Closure.py
+++ b/owlrl/Closure.py
@@ -27,8 +27,13 @@ __license__ = "W3C® SOFTWARE NOTICE AND LICENSE, http://www.w3.org/Consortium/L
 
 import rdflib
 from rdflib.namespace import RDF
-from rdflib import BNode, Literal
+from rdflib import BNode, Literal, Graph, Dataset
 from .Namespaces import ERRNS
+
+try:
+    from rdflib.graph import ConjunctiveGraph
+except ImportError:
+    ConjunctiveGraph = Dataset
 
 debugGlobal = False
 offlineGeneration = False
@@ -111,6 +116,8 @@ class Core:
         self.IMaxNum = maxnum
 
         self.graph = graph
+        if isinstance(self.graph, (Dataset, ConjunctiveGraph)):
+            self.graph.default_union = True
         self.axioms = axioms
         self.daxioms = daxioms
 
@@ -271,7 +278,7 @@ class Core:
             self.empty_stored_triples()
 
             # Execute all the rules; these might fill up the added triples array
-            for t in self.graph:
+            for t in self.graph.triples((None, None, None)):
                 self.rules(t, cycle_num)
 
             # Add the tuples to the graph (if necessary, that is). If any new triple has been generated, a new cycle

--- a/owlrl/CombinedClosure.py
+++ b/owlrl/CombinedClosure.py
@@ -29,6 +29,9 @@ __author__ = "Ivan Herman"
 __contact__ = "Ivan Herman, ivan@w3.org"
 __license__ = "W3C® SOFTWARE NOTICE AND LICENSE, http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231"
 
+from typing import Union
+
+from rdflib import Graph
 from rdflib.namespace import OWL, RDF, RDFS
 
 from owlrl.RDFSClosure import RDFS_Semantics
@@ -42,7 +45,7 @@ class RDFS_OWLRL_Semantics(RDFS_Semantics, OWLRL_Semantics):
     """
     Common subclass of the RDFS and OWL 2 RL semantic classes. All methods simply call back
     to the functions in the superclasses. This may lead to some unnecessary duplication of terms
-    and rules, but it it not so bad. Also, the additional identification defined for OWL Full,
+    and rules, but it is not so bad. Also, the additional identification defined for OWL Full,
     ie, Resource being the same as Thing and OWL and RDFS classes being identical are added to the
     triple store.
 
@@ -76,7 +79,7 @@ class RDFS_OWLRL_Semantics(RDFS_Semantics, OWLRL_Semantics):
         (OWL.DataRange, OWL.equivalentClass, RDFS.Datatype),
     ]
 
-    def __init__(self, graph, axioms, daxioms, rdfs=True):
+    def __init__(self, graph: Graph, axioms, daxioms, rdfs: bool = True, destination: Union[None, Graph] = None):
         """
         @param graph: the RDF graph to be extended
         @type graph: rdflib.Graph
@@ -86,9 +89,11 @@ class RDFS_OWLRL_Semantics(RDFS_Semantics, OWLRL_Semantics):
         @type daxioms: bool
         @param rdfs: placeholder flag (used in subclassed only, it is always defaulted to True in this class)
         @type rdfs: boolean
+        @param destination: the destination graph to which the results are written. If None, use the source graph.
+        @type destination: rdflib.Graph
         """
-        OWLRL_Semantics.__init__(self, graph, axioms, daxioms, rdfs)
-        RDFS_Semantics.__init__(self, graph, axioms, daxioms, rdfs)
+        OWLRL_Semantics.__init__(self, graph, axioms, daxioms, rdfs=rdfs, destination=destination)
+        RDFS_Semantics.__init__(self, graph, axioms, daxioms, rdfs=rdfs, destination=destination)
         self.rdfs = True
 
     # noinspection PyMethodMayBeStatic

--- a/owlrl/OWLRL.py
+++ b/owlrl/OWLRL.py
@@ -200,7 +200,7 @@ class OWLRL_Semantics(Core):
         # literals which are present in the graph
         implicit = {
             o: o.datatype
-            for s, p, o in self.graph
+            for s, p, o in self.graph.triples((None, None, None))
             if isinstance(o, rdflib.Literal) and o.datatype in OWL_RL_Datatypes
         }
 

--- a/owlrl/OWLRL.py
+++ b/owlrl/OWLRL.py
@@ -32,9 +32,10 @@ __contact__ = "Ivan Herman, ivan@w3.org"
 __license__ = "W3C® SOFTWARE NOTICE AND LICENSE, http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231"
 
 from collections import defaultdict
+from typing import Union
 
 import rdflib
-from rdflib import BNode
+from rdflib import BNode, Graph
 from rdflib.namespace import OWL, RDF, RDFS
 
 from owlrl.Closure import Core
@@ -98,7 +99,7 @@ class OWLRL_Semantics(Core):
     :type rdfs: bool
     """
 
-    def __init__(self, graph, axioms, daxioms, rdfs=None):
+    def __init__(self, graph: Graph, axioms, daxioms, rdfs: bool = False, destination: Union[None, Graph] = None):
         """
         @param graph: the RDF graph to be extended
         @type graph: rdflib.Graph
@@ -108,8 +109,10 @@ class OWLRL_Semantics(Core):
         @type daxioms: bool
         @param rdfs: whether RDFS inference is also done (used in subclassed only)
         @type rdfs: boolean
+        @param destination: the destination graph to which the results are written. If None, use the source graph.
+        @type destination: rdflib.Graph
         """
-        Core.__init__(self, graph, axioms, daxioms, rdfs)
+        Core.__init__(self, graph, axioms, daxioms, rdfs=rdfs, destination=destination)
         self.bnodes = []
 
     def _list(self, l):
@@ -131,6 +134,7 @@ class OWLRL_Semantics(Core):
                 if t not in to_be_removed:
                     to_be_removed.append(t)
         for t in to_be_removed:
+            self.destination.remove(t)
             self.graph.remove(t)
 
     def add_axioms(self):
@@ -138,14 +142,14 @@ class OWLRL_Semantics(Core):
         Add axioms
         """
         for t in OWLRL_Axiomatic_Triples:
-            self.graph.add(t)
+            self.destination.add(t)
 
     def add_d_axioms(self):
         """
         Add the datatype axioms
         """
         for t in OWLRL_D_Axiomatic_Triples:
-            self.graph.add(t)
+            self.destination.add(t)
 
     def restriction_typing_check(self, v, t):
         """

--- a/owlrl/OWLRLExtras.py
+++ b/owlrl/OWLRLExtras.py
@@ -308,7 +308,7 @@ class OWLRL_Extension_Trimming(OWLRL_Extension):
         self.flush_stored_triples()
 
         to_be_removed = set()
-        for t in self.graph:
+        for t in self.graph.triples((None, None, None)):
             s, p, o = t
             if s == o:
                 if (

--- a/owlrl/OWLRLExtras.py
+++ b/owlrl/OWLRLExtras.py
@@ -39,7 +39,10 @@ __author__ = "Ivan Herman"
 __contact__ = "Ivan Herman, ivan@w3.org"
 __license__ = "W3C® SOFTWARE NOTICE AND LICENSE, http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231"
 
+from typing import Union
+
 import rdflib
+from rdflib import Graph
 from rdflib.namespace import RDF, RDFS, OWL, XSD
 
 from fractions import Fraction as Rational
@@ -116,7 +119,7 @@ class OWLRL_Extension(RDFS_OWLRL_Semantics):
         (OWL.hasSelf, RDFS.domain, RDF.Property),
     ]
 
-    def __init__(self, graph, axioms, daxioms, rdfs=False):
+    def __init__(self, graph: Graph, axioms, daxioms, rdfs: bool = False, destination: Union[None, Graph] = None):
         """
         @param graph: the RDF graph to be extended
         @type graph: rdflib.Graph
@@ -126,8 +129,10 @@ class OWLRL_Extension(RDFS_OWLRL_Semantics):
         @type daxioms: Boolean
         @param rdfs: whether RDFS extension is done
         @type rdfs: boolean
+        @param destination: the destination graph to which the results are written. If None, use the source graph.
+        @type destination: rdflib.Graph
         """
-        RDFS_OWLRL_Semantics.__init__(self, graph, axioms, daxioms, rdfs)
+        RDFS_OWLRL_Semantics.__init__(self, graph, axioms, daxioms, rdfs=rdfs, destination=destination)
         self.rdfs = rdfs
         self.add_new_datatype(
             OWL.rational,
@@ -226,7 +231,7 @@ class OWLRL_Extension(RDFS_OWLRL_Semantics):
         """
         RDFS_OWLRL_Semantics.add_axioms(self)
         for t in self.extra_axioms:
-            self.graph.add(t)
+            self.destination.add(t)
 
     def rules(self, t, cycle_num):
         """
@@ -286,7 +291,7 @@ class OWLRL_Extension_Trimming(OWLRL_Extension):
     :type rdfs: bool
     """
 
-    def __init__(self, graph, axioms, daxioms, rdfs=False):
+    def __init__(self, graph: Graph, axioms, daxioms, rdfs: bool = False, destination: Union[None, Graph] = None):
         """
         @param graph: the RDF graph to be extended
         @type graph: rdflib.Graph
@@ -296,8 +301,10 @@ class OWLRL_Extension_Trimming(OWLRL_Extension):
         @type daxioms: Boolean
         @param rdfs: whether RDFS extension is done
         @type rdfs: boolean
+        @param destination: the destination graph to which the results are written. If None, use the source graph.
+        @type destination: rdflib.Graph
         """
-        OWLRL_Extension.__init__(self, graph, axioms, daxioms, rdfs=False)
+        OWLRL_Extension.__init__(self, graph, axioms, daxioms, rdfs=rdfs, destination=destination)
 
     def post_process(self):
         """
@@ -337,7 +344,7 @@ class OWLRL_Extension_Trimming(OWLRL_Extension):
                     to_be_removed.add(t)
 
         for an in OWLRL_Annotation_properties:
-            self.graph.remove((an, RDF.type, OWL.AnnotationProperty))
+            self.destination.remove((an, RDF.type, OWL.AnnotationProperty))
 
         to_be_removed.add((OWL.Nothing, RDF.type, OWL.Class))
         to_be_removed.add((OWL.Nothing, RDF.type, RDFS.Class))
@@ -355,4 +362,4 @@ class OWLRL_Extension_Trimming(OWLRL_Extension):
         to_be_removed.add((OWL.DataRange, OWL.equivalentClass, OWL.DatatypeProperty))
 
         for t in to_be_removed:
-            self.graph.remove(t)
+            self.destination.remove(t)

--- a/owlrl/RDFSClosure.py
+++ b/owlrl/RDFSClosure.py
@@ -198,4 +198,7 @@ class RDFS_Semantics(Core):
         """
         Get all literals defined in the graph.
         """
-        return set(o for s, p, o in self.graph if isinstance(o, Literal))
+        return set(
+            o for s, p, o in self.graph.triples((None, None, None))
+            if isinstance(o, Literal)
+        )

--- a/owlrl/__init__.py
+++ b/owlrl/__init__.py
@@ -165,6 +165,8 @@ __author__ = "Ivan Herman"
 __contact__ = "Ivan Herman, ivan@w3.org"
 __license__ = "W3C® SOFTWARE NOTICE AND LICENSE, http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231"
 
+from typing import Union
+
 # noinspection PyPackageRequirements,PyPackageRequirements,PyPackageRequirements
 import rdflib
 from rdflib import Graph, Literal
@@ -384,19 +386,25 @@ class DeductiveClosure:
         self.rdfs_closure = rdfs_closure
         self.improved_datatypes = improved_datatypes
 
-    def expand(self, graph):
+    def expand(self, graph: Graph, destination: Union[None, Graph] = None):
         """
         Expand the graph using forward chaining, and with the relevant closure type.
 
         :param graph: The RDF graph.
         :type graph: :class:`rdflib.Graph`
+        :param destination: The RDF graph to which the results are written. If not specified, the graph is modified in-place.
+        :type destination: :class:`rdflib.Graph`
         """
         if (not DeductiveClosure.improved_datatype_generic) and self.improved_datatypes:
             DatatypeHandling.use_Alt_lexical_conversions()
 
         if self.closure_class is not None:
             self.closure_class(
-                graph, self.axiomatic_triples, self.datatype_axioms, self.rdfs_closure
+                graph,
+                self.axiomatic_triples,
+                self.datatype_axioms,
+                rdfs=self.rdfs_closure,
+                destination=destination
             ).closure()
 
         if (not DeductiveClosure.improved_datatype_generic) and self.improved_datatypes:

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -1,0 +1,134 @@
+from rdflib import Graph, Namespace, Dataset, URIRef
+from rdflib.namespace import RDF
+import sys
+from pathlib import Path
+
+try:
+    from rdflib.graph import ConjunctiveGraph
+    # ConjunctiveGraph is going away in rdflib 8.0
+except ImportError:
+    ConjunctiveGraph = Dataset
+
+sys.path.append(str(Path(__file__).parent.parent))
+import owlrl
+
+RELS = Namespace("http://example.org/relatives#")
+
+
+def test_dataset():
+    # create an RDF graph, load a simple OWL ontology and data
+    d = Dataset()
+    d.default_union = True
+    g = d.default_context
+    try:
+        g.parse("relatives.ttl", format="turtle")
+    except FileNotFoundError:
+        # This test might be run from the parent directory root
+        g.parse("test/relatives.ttl", format="turtle")
+
+    # count no. rels:Person class instances, no inferencing, should find 14 results (one Child)
+    cnt = 0
+    for _ in d.subjects(predicate=RDF.type, object=RELS.Person):
+        cnt += 1
+
+    assert cnt == 14
+    dest = d.graph(identifier=URIRef("urn:test:dest"))
+    # count no. of hasGrandparent predicates, no inferencing, should find 0 results
+    cnt = 0
+    for _ in d.subject_objects(predicate=RELS.hasGrandparent):
+        cnt += 1
+    assert cnt == 0
+
+    # expand the graph with OWL-RL semantics
+    owlrl.DeductiveClosure(owlrl.OWLRL_Semantics).expand(d, destination=dest)
+
+    # count no. rels:Person class instances, after inferencing, should find 1 result in the Dest graph
+    cnt = 0
+    for _ in dest.subjects(predicate=RDF.type, object=RELS.Person):
+        cnt += 1
+
+    assert cnt == 1
+
+    # count no. rels:Person class instances, after inferencing, should find 15 results in the whole dataset
+    cnt = 0
+    for _ in d.subjects(predicate=RDF.type, object=RELS.Person):
+        cnt += 1
+
+    assert cnt == 15
+
+    # count no. of hasGrandparent predicates, after inferencing, should find 7 results in the Dest graph
+    cnt = 0
+    for _ in dest.subject_objects(predicate=RELS.hasGrandparent):
+        cnt += 1
+    assert cnt == 7
+
+    # count no. of hasGrandparent predicates, after inferencing, should find 7 results in the whole dataset
+    cnt = 0
+    for _ in d.subject_objects(predicate=RELS.hasGrandparent):
+        cnt += 1
+    assert cnt == 7
+
+    # count no. of hasGrandparent predicates, after inferencing, should find 0 results in the default graph
+    cnt = 0
+    for _ in g.subject_objects(predicate=RELS.hasGrandparent):
+        cnt += 1
+    assert cnt == 0
+
+
+def test_conjunctive_graph():
+    # create an RDF graph, load a simple OWL ontology and data
+    d = ConjunctiveGraph()
+    g = d.default_context
+    try:
+        g.parse("relatives.ttl", format="turtle")
+    except FileNotFoundError:
+        # This test might be run from the parent directory root
+        g.parse("test/relatives.ttl", format="turtle")
+
+    # count no. rels:Person class instances, no inferencing, should find 14 results (one Child)
+    cnt = 0
+    for _ in d.subjects(predicate=RDF.type, object=RELS.Person):
+        cnt += 1
+
+    assert cnt == 14
+    dest = d.get_context(URIRef("urn:test:dest"))
+    # count no. of hasGrandparent predicates, no inferencing, should find 0 results
+    cnt = 0
+    for _ in d.subject_objects(predicate=RELS.hasGrandparent):
+        cnt += 1
+    assert cnt == 0
+
+    # expand the graph with OWL-RL semantics
+    owlrl.DeductiveClosure(owlrl.OWLRL_Semantics).expand(d, destination=dest)
+
+    # count no. rels:Person class instances, after inferencing, should find 1 result in the Dest graph
+    cnt = 0
+    for _ in dest.subjects(predicate=RDF.type, object=RELS.Person):
+        cnt += 1
+
+    assert cnt == 1
+
+    # count no. rels:Person class instances, after inferencing, should find 15 results in the whole dataset
+    cnt = 0
+    for _ in d.subjects(predicate=RDF.type, object=RELS.Person):
+        cnt += 1
+
+    assert cnt == 15
+
+    # count no. of hasGrandparent predicates, after inferencing, should find 7 results in the Dest graph
+    cnt = 0
+    for _ in dest.subject_objects(predicate=RELS.hasGrandparent):
+        cnt += 1
+    assert cnt == 7
+
+    # count no. of hasGrandparent predicates, after inferencing, should find 7 results in the whole dataset
+    cnt = 0
+    for _ in d.subject_objects(predicate=RELS.hasGrandparent):
+        cnt += 1
+    assert cnt == 7
+
+    # count no. of hasGrandparent predicates, after inferencing, should find 0 results in the default graph
+    cnt = 0
+    for _ in g.subject_objects(predicate=RELS.hasGrandparent):
+        cnt += 1
+    assert cnt == 0


### PR DESCRIPTION
Add ability to place generated triples into a different named graph, using `destination` argument on expand().


Note, this relies on and builds-upon PR #69 
