### PR TITLE
Report version from installed metadata version at runtime

### DIFF
--- a/owlrl/__init__.py
+++ b/owlrl/__init__.py
@@ -155,7 +155,7 @@ which will result in a proper graph expansion except for the datatype specific c
 """
 
 # Examples: LangString is disjoint from String
-__version__ = "7.5.0"
+__version__ = f"{__import__('importlib.metdata').metadata.version('owl-rl')}"
 __author__ = "Ivan Herman"
 __contact__ = "Ivan Herman, ivan@w3.org"
 __license__ = "W3C® SOFTWARE NOTICE AND LICENSE, http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231"

--- a/owlrl/__init__.py
+++ b/owlrl/__init__.py
@@ -155,7 +155,7 @@ which will result in a proper graph expansion except for the datatype specific c
 """
 
 # Examples: LangString is disjoint from String
-__version__ = f"{__import__('importlib.metdata').metadata.version('owl-rl')}"
+__version__ = f"{__import__('importlib.metadata').metadata.version('owl-rl')}"
 __author__ = "Ivan Herman"
 __contact__ = "Ivan Herman, ivan@w3.org"
 __license__ = "W3C® SOFTWARE NOTICE AND LICENSE, http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231"


### PR DESCRIPTION
Congratulations on 7.6.1! :tada: 

This PR aligns `__version__.py` with `pyproject.toml` "once and for all" by using `importlib.metadata.version`.

Downsides:
- won't work with a `git clone` and `sys.prefix` hacks
  - ... but _will_ work with e.g. `git+https` or `owl-rl @ https://` PEP-508 specs

Alternatives:
- treat _this_ instance of the version as canonical
  - this makes `pyproject.toml` a bit less useful as a provenance artifact
- have a plain text `VERSION` file read by both
  - kind of fiddly on both sides
- add a test that checks for the two instances the same 
  - more code

References:
- patching on https://github.com/conda-forge/owlrl-feedstock/pull/9